### PR TITLE
platform_testing: Remove host_tests to fix custom out dir builds

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -109,10 +109,6 @@ test_package {
         "mmapPerf",
         "xaVideoDecoderCapabilities",
     ],
-    host_tests: [
-        "perfetto_trace_processor_shell",
-        "root-canal",
-    ],
     tests_if_exist_common: [
         "AndroidAutoScenarioTests",
         "BiometricsMicrobenchmark",


### PR DESCRIPTION
Remove host_tests section that caused Soong path validation errors when building with custom output directories.
The individual test modules are still built independently.

fixes:
error: platform_testing/Android.bp:5:1: module "platform_tests" variant "android_common": Path is outside directory: $customoutdir/rom/host/linux-x86/bin/perfetto_trace_processor_shell error: platform_testing/Android.bp:5:1: module "platform_tests" variant "android_common": Path is outside directory: $customoutdir/rom/host/linux-x86/bin/root-canal